### PR TITLE
Crop task branch1

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/traySeedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/traySeedingReport.html
@@ -48,7 +48,7 @@
 
             <tr v-for="(log, index) in traySeedingLogs">
                 <td>{{ timestampToYMD(log.date) }}</td>
-                <td>{{ }}</td>
+                <td>{{ log.crop }}</td>
                 <td>{{ }}</td>
                 <td>     </td>
                 <td>     </td>
@@ -124,7 +124,8 @@
                 traySeedingLogRequest: function() {
                     let s = this.YMDToTimestamp(this.reportStart);
                     let e = this.YMDToTimestamp(this.reportEnd);
-                    axios.get('/log.json?type=farm_seeding&timestamp[ge]=' + s + '&timestamp[le]=' + e)
+                    if(this.rptCrop == 'All'){
+                        axios.get('/log.json?type=farm_seeding&timestamp[ge]=' + s + '&timestamp[le]=' + e )
                         .then(response => {
                             this.traySeedingLogs = response.data.list.map(t => {
                                 return {
@@ -134,6 +135,18 @@
                                 };
                             });
                         })
+                    } else {
+                        axios.get('/log.json?type=farm_seeding&timestamp[ge]=' + s + '&timestamp[le]=' + e + '&name=Seed%20' + this.rptCrop)
+                        .then(response => {
+                            this.traySeedingLogs = response.data.list.map(t => {
+                                return {
+                                    date:t.timestamp,
+                                    crop:t.name,
+                                    numSeeds:t.quantity,
+                                };
+                            });
+                        })
+                    }
                     this.state = 'edit';
                 },
              },


### PR DESCRIPTION
__Pull Request Description__

Now the table generates data from the farmOS API that corresponds to the date range chosen and the crop selected. For example, if we want to see the tray seeding logs for the "Dill" crop from July 7, 2018 to August 7, 2018, we can now do that. Also, the "All" option for the crops also works now, allowing the farmworker to see all tray seeding crops within a specified date range. 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
